### PR TITLE
Display a valid "joinded" information

### DIFF
--- a/app/views/_elements/cards/account.volt
+++ b/app/views/_elements/cards/account.volt
@@ -9,7 +9,7 @@
       </a>
     </div>
     <div class="meta">
-      joined <?php echo $this->timeAgo::mongo($account->created); ?>
+      joined <?php echo $this->timeAgo::mongo(date("Y",$account->created) < 2016 ? "2016-10-18" : $account->created); ?>
       </a>
     </div>
 <!--


### PR DESCRIPTION
Accounts created at genesis of Golos display "joined 46 years ago ". Looks weird ...
This is because the "created" date in the blockchain was set to "1970-01-01 00:00:00.000" for those accounts
Checking for if created is prior genesis date (2016-10-18) and replacing it by genesis date if true will look better.