### PR TITLE
 Improve how post vs comment are displayed in account history

### DIFF
--- a/app/views/_elements/tx/comment.volt
+++ b/app/views/_elements/tx/comment.volt
@@ -1,7 +1,12 @@
 <a href="/@{{ item[1]['op'][1]['author'] }}" class="ui label">
   {{ item[1]['op'][1]['author'] }}
 </a>
-replied to
+{{ item[1]['op'][1]['title'] == '' ? 'replied to ' 
 <a href="/tag/@{{ item[1]['op'][1]['parent_author'] }}/{{ item[1]['op'][1]['parent_permlink'] }}">
   <?= substr($item[1]['op'][1]['parent_permlink'], 0, 75) ?>
 </a>
+: 'posted '
+<a href="/{{ item[1]['op'][1]['parent_permlink'] }}/@{{ item[1]['op'][1]['author'] }}/{{ item[1]['op'][1]['permlink'] }}">
+  <?= substr($item[1]['op'][1]['title'], 0, 75) ?>
+</a>
+}}


### PR DESCRIPTION
Currently, posts and comments are both display as "replied to"
I'm not quite sure of the volt syntax, but code should be something like this.
This change could also applied to steemdb.com